### PR TITLE
Update yggdrasil.spec to fix EPEL8 build errors

### DIFF
--- a/yggdrasil.spec
+++ b/yggdrasil.spec
@@ -18,6 +18,8 @@ network routing. Whereas current computer networks depend heavily on very
 centralised design and configuration, Yggdrasil breaks this mould by making
 use of a global spanning tree to form a scalable IPv6 encrypted mesh network.
 
+%define debug_package %{nil}
+
 %pre
 getent group yggdrasil >/dev/null || groupadd -r yggdrasil
 exit 0


### PR DESCRIPTION
Failing to set this seems to break builds for EPEL8. This fix leads to successful builds on EPEL8.

Before [https://copr-be.cloud.fedoraproject.org/results/dstutman/yggdrasil/epel-8-x86_64/01140100-yggdrasil/builder-live.log.gz]()

After [https://copr-be.cloud.fedoraproject.org/results/dstutman/yggdrasil/epel-8-x86_64/01140150-yggdrasil/builder-live.log.gz]()