### PR TITLE
Use systemd unitdir

### DIFF
--- a/yggdrasil.spec
+++ b/yggdrasil.spec
@@ -36,15 +36,15 @@ export PKGVER="%{version}"
 %install
 rm -rf %{buildroot}
 mkdir -p %{buildroot}/%{_bindir}
-mkdir -p %{buildroot}/%{_sysconfdir}/systemd/system
+mkdir -p %{buildroot}/%{_unitdir}
 install -m 0755 yggdrasil %{buildroot}/%{_bindir}/yggdrasil
 install -m 0755 yggdrasilctl %{buildroot}/%{_bindir}/yggdrasilctl
-install -m 0755 contrib/systemd/yggdrasil.service %{buildroot}/%{_sysconfdir}/systemd/system/yggdrasil.service
+install -m 0755 contrib/systemd/yggdrasil.service %{buildroot}/%{_unitdir}/yggdrasil.service
 
 %files
 %{_bindir}/yggdrasil
 %{_bindir}/yggdrasilctl
-%{_sysconfdir}/systemd/system/yggdrasil.service
+%{_unitdir}/yggdrasil.service
 
 %post
 %systemd_post yggdrasil.service

--- a/yggdrasil.spec
+++ b/yggdrasil.spec
@@ -35,11 +35,9 @@ export PKGVER="%{version}"
 
 %install
 rm -rf %{buildroot}
-mkdir -p %{buildroot}/%{_bindir}
-mkdir -p %{buildroot}/%{_unitdir}
-install -m 0755 yggdrasil %{buildroot}/%{_bindir}/yggdrasil
-install -m 0755 yggdrasilctl %{buildroot}/%{_bindir}/yggdrasilctl
-install -m 0755 contrib/systemd/yggdrasil.service %{buildroot}/%{_unitdir}/yggdrasil.service
+install -m 0755 -D yggdrasil %{buildroot}/%{_bindir}/yggdrasil
+install -m 0755 -D yggdrasilctl %{buildroot}/%{_bindir}/yggdrasilctl
+install -m 0755 -D contrib/systemd/yggdrasil.service %{buildroot}/%{_unitdir}/yggdrasil.service
 
 %files
 %{_bindir}/yggdrasil


### PR DESCRIPTION
Currently this is placing the service file in `/etc/systemd/system`, even though this is reserved for administrators for overriding package installed service files. This PR moves the service file to the correct path, `/usr/lib/systemd/system` by using the provided rpm macro `_unitdir`.

Bonus: I added a commit to let `install` handle directory creation. You can cherry pick the first commit if you don't like the second one.

P.S. Package signing is still broken for CentOS users, and probably Fedora too.