### PR TITLE
Generate /etc/yggdrasil.conf automatically after install or update

### DIFF
--- a/yggdrasil.spec
+++ b/yggdrasil.spec
@@ -45,6 +45,21 @@ install -m 0755 -D contrib/systemd/yggdrasil.service %{buildroot}/%{_sysconfdir}
 %{_sysconfdir}/systemd/system/yggdrasil.service
 
 %post
+if [ -e %{_sysconfdir}/yggdrasil.conf ]; then
+    TMPDIR=$(mktemp -d)
+    %{_bindir}/yggdrasil -useconffile %{_sysconfdir}/yggdrasil.conf -normaliseconf > $TMPDIR/yggdrasil.conf
+    if ! cmp -s "%{_sysconfdir}/yggdrasil.conf" "$TMPDIR/yggdrasil.conf"; then
+        mv -f "$TMPDIR/yggdrasil.conf" "%{_sysconfdir}/yggdrasil.conf.rpmnew"
+        chmod 640 %{_sysconfdir}/yggdrasil.conf.rpmnew
+        echo "An updated %{_sysconfdir}/yggdrasil.conf was saved as %{_sysconfdir}/yggdrasil.conf.rpmnew"
+    fi
+    rm -rf $TMPDIR
+else
+    echo "Generating initial configuration file %{_sysconfdir}/yggdrasil.conf"
+    echo "Please familiarize yourself with this file before starting Yggdrasil"
+    %{_bindir}/yggdrasil -genconf > %{_sysconfdir}/yggdrasil.conf
+    chmod 640 %{_sysconfdir}/yggdrasil.conf
+fi
 %systemd_post yggdrasil.service
 
 %preun


### PR DESCRIPTION
After this change `/etc/yggdrasil.conf` will be created automatically after `install` and `update`. It will work by this scheme:
1) Check if `/etc/yggdrasil.conf` already exists.
2) If not, then generate a new config via `yggdrasil -genconf`
3) If this config file was found, then:
a) Regenerate it via `yggdrasil -useconffile /etc/yggdrasil.conf -normaliseconf` to a temp file
b) Compare the new config with the current one
c) If they are different then save the new config as `/etc/yggdrasil.conf.rpmnew` (original `/etc/yggdrasil.conf` will be untouched).

I am not so happy with this method, since in my opinion the default yggdrasil.conf should be packaged inside RPM. And then update it using standard `%config(noreplace)` RPM's macros. But then there is no easy way to automatically update and put the secret keys in the config after the first launch of Yggdrasil.
